### PR TITLE
chore(deps): override js-yaml to ^4.3.0 to fix CVE-2026-59869

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5324,9 +5324,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
   },
   "overrides": {
     "lodash": "^4.18.1",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "js-yaml": "^4.3.0"
   },
   "prisma": {
     "seed": "npx ts-node -T prisma/seed.ts"


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#106](https://github.com/ucalyptus/sulajh/security/dependabot/106) (GHSA-52cp-r559-cp3m / CVE-2026-59869, **High / CVSS 7.5**).

`js-yaml` <4.3.0 is vulnerable to quadratic CPU consumption when parsing YAML documents that chain merge keys, allowing a small document to burn O(N²) CPU.

## Fix

The vulnerable version reaches this repo transitively:

```
sulajh
└─ @tanstack/react-start@1.168.25
   └─ @tanstack/start-plugin-core@1.171.17
      └─ xmlbuilder2@4.0.3
         └─ js-yaml@4.2.0  ← vulnerable
```

The parent `xmlbuilder2@4.0.3` declares `js-yaml: ^4.1.1`, so `4.3.0` satisfies its range and no API changes are required. This PR adds an `npm` `overrides` entry pinning the transitive `js-yaml` to `^4.3.0` and regenerates `package-lock.json`.

After the fix:

```
└─ xmlbuilder2@4.0.3
   └─ js-yaml@4.3.0 overridden
```

`npm audit` no longer reports `js-yaml`. The two remaining audit findings (`brace-expansion`, `postcss`) are pre-existing and unrelated to this alert.