### PR TITLE
chore(deps): bump postcss to ^8.5.18 to fix GHSA-r28c-9q8g-f849

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "@types/react-dom": "^18",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^6.0.2",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.18",
         "prisma": "^6.5.0",
         "tailwindcss": "^3.4.17",
         "typescript": "^5",
@@ -6434,9 +6434,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6783,9 +6783,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -6803,7 +6803,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@types/react-dom": "^18",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^6.0.2",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "prisma": "^6.5.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5",
@@ -99,7 +99,7 @@
   },
   "overrides": {
     "lodash": "^4.18.1",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "js-yaml": "^4.3.0"
   },
   "prisma": {


### PR DESCRIPTION
## Summary

Bumps `postcss` from a resolved 8.5.14 to 8.5.24 to close [GHSA-r28c-9q8g-f849](https://github.com/postcss/postcss/security/advisories/GHSA-r28c-9q8g-f849) (**high**, CVSS 7.5).

Fixes Dependabot alert [#108](https://github.com/ucalyptus/sulajh/security/dependabot/108).

## Vulnerability

PostCSS `<= 8.5.17` auto-loads a `sourceMappingURL` referenced in the CSS it parses (opt-out via `map: false`, not opt-in) and joins the annotation onto `dirname(opts.from)` without sandboxing `..` segments. If `opts.from` is unset, an absolute path in the annotation is used verbatim.

Any service that runs untrusted CSS through PostCSS with default options and later serves/returns `result.map` (the common bundler pattern) can be tricked into disclosing the contents of arbitrary `.map` files reachable from the process. Patched in 8.5.18 by constraining the resolved path to remain inside the CSS file's directory.

## Changes

- `package.json`: bump `postcss` devDependency and `overrides.postcss` from `^8.5.10` → `^8.5.18`.
- `package-lock.json`: refreshed so every postcss reference (direct, plus transitives via `autoprefixer`, `tailwindcss`, `vite`, `postcss-import`, `postcss-js`, `postcss-load-config`, `postcss-nested`) resolves to `8.5.24`. `nanoid` bumped from `3.3.11` → `3.3.16` as a transitive side-effect of postcss's own dep bump.

Same override-driven approach as prior alert-#106 fix (#18).

## Verification

- `npm ls postcss` now shows every entry deduped to `postcss@8.5.24`.
- `npm run build` succeeds locally with the patched version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>